### PR TITLE
[PR1] DEV-2 Added Control Sections

### DIFF
--- a/src/components/ControlSections/ControlSections.module.scss
+++ b/src/components/ControlSections/ControlSections.module.scss
@@ -1,0 +1,4 @@
+.podSectionWrapper {
+    display: flex;
+    flex-direction: row;
+}

--- a/src/components/ControlSections/ControlSections.tsx
+++ b/src/components/ControlSections/ControlSections.tsx
@@ -1,0 +1,19 @@
+import styles from "components/ControlSections/ControlSections.module.scss";
+import { useState } from "react";
+import { PneumaticsSection } from "components/ControlSections/PneumaticsSection/PneumaticsSection";
+import { ControlData } from "components/ControlSections/types/ControlData";
+import { NavigationSection } from "components/ControlSections/NavigationSection/NavigationSection";
+type Props = {
+    controlData: ControlData;
+};
+
+export const ControlSections = ({ controlData }: Props) => {
+    return (
+        <section className={styles.podSectionsWrapper}>
+            <PneumaticsSection pneumaticsData={controlData.pneumaticsData} />
+            <NavigationSection
+                navigationData={controlData.navigationData}
+            ></NavigationSection>
+        </section>
+    );
+};

--- a/src/components/ControlSections/NavigationSection/NavigationData.ts
+++ b/src/components/ControlSections/NavigationSection/NavigationData.ts
@@ -1,0 +1,10 @@
+import { getDefaultMeasurement } from "models/PodData/Measurement";
+import { SectionData } from "components/ControlSections/types/SectionData";
+import { ModelNameMap } from "components/ControlSections/types/SectionData";
+export type NavigationProperties =
+    | "velocity"
+    | "position"
+    | "additionalMeasurements";
+
+export type NavigationDataNameMap = ModelNameMap<NavigationProperties>;
+export type NavigationData = SectionData<NavigationProperties>;

--- a/src/components/ControlSections/NavigationSection/NavigationSection.tsx
+++ b/src/components/ControlSections/NavigationSection/NavigationSection.tsx
@@ -1,0 +1,10 @@
+import styles from "components/ControlSections/NavigationSection/NavigationSection.module.scss";
+import { NavigationData } from "components/ControlSections/NavigationSection/NavigationData";
+
+type Props = {
+    navigationData: NavigationData;
+};
+
+export const NavigationSection = ({ navigationData }: Props) => {
+    return <div>{JSON.stringify(navigationData)}</div>;
+};

--- a/src/components/ControlSections/PneumaticsSection/PneumaticsData.ts
+++ b/src/components/ControlSections/PneumaticsSection/PneumaticsData.ts
@@ -1,0 +1,11 @@
+import { SectionData } from "components/ControlSections/types/SectionData";
+
+export type PneumaticsProperties =
+    | "bottle1"
+    | "bottle2"
+    | "lowPressure"
+    | "midPressure"
+    | "highPressure"
+    | "additionalValues";
+
+export type PneumaticsData = SectionData<PneumaticsProperties>;

--- a/src/components/ControlSections/PneumaticsSection/PneumaticsSection.module.scss
+++ b/src/components/ControlSections/PneumaticsSection/PneumaticsSection.module.scss
@@ -1,0 +1,8 @@
+.pneumaticsSectionWrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.otherTags {
+    background-color: red;
+}

--- a/src/components/ControlSections/PneumaticsSection/PneumaticsSection.tsx
+++ b/src/components/ControlSections/PneumaticsSection/PneumaticsSection.tsx
@@ -1,0 +1,32 @@
+import styles from "components/ControlSections/PneumaticsSection/PneumaticsSection.module.scss";
+import { ValueTag } from "components/ValueTag/ValueTag";
+import {
+    PneumaticsProperties,
+    PneumaticsData,
+} from "components/ControlSections/PneumaticsSection/PneumaticsData";
+
+type Props = {
+    pneumaticsData: PneumaticsData;
+};
+
+export const PneumaticsSection = ({ pneumaticsData }: Props) => {
+    return (
+        <section className={styles.pneumaticsSectionWrapper}>
+            <ValueTag measurement={pneumaticsData.bottle1} />
+            <ValueTag measurement={pneumaticsData.bottle2} />
+            <ValueTag measurement={pneumaticsData.highPressure} />
+            <ValueTag measurement={pneumaticsData.midPressure} />
+            <ValueTag measurement={pneumaticsData.lowPressure} />
+            <div className={styles.otherTags}>
+                {pneumaticsData.additionalValues.map((measurement) => {
+                    return (
+                        <ValueTag
+                            key={measurement.name}
+                            measurement={measurement}
+                        />
+                    );
+                })}
+            </div>
+        </section>
+    );
+};

--- a/src/components/ControlSections/fetchControlSections.ts
+++ b/src/components/ControlSections/fetchControlSections.ts
@@ -1,0 +1,13 @@
+import { ControlDataNameMap } from "components/ControlSections/types/ControlData";
+import { fetchFromBackend } from "services/HTTPHandler";
+import { setControlSections } from "slices/controlSectionsSlice";
+import { store } from "store";
+
+export async function fetchControlSections(): Promise<ControlDataNameMap> {
+    const response = await fetchFromBackend(
+        import.meta.env.VITE_CONTROL_SECTIONS_PATH
+    );
+    const controlSections = await response.json();
+    store.dispatch(setControlSections(controlSections));
+    return controlSections as ControlDataNameMap;
+}

--- a/src/components/ControlSections/hooks/useControlData.ts
+++ b/src/components/ControlSections/hooks/useControlData.ts
@@ -1,0 +1,30 @@
+import {
+    ControlData,
+    ControlDataNameMap,
+} from "components/ControlSections/types/ControlData";
+import { PodData } from "models/PodData/PodData";
+import { useSectionData } from "./useSectionData";
+
+export function useControlData(
+    controlDataNameMap: ControlDataNameMap
+): [ControlData, (boards: PodData["boards"]) => void] {
+    const [pneumaticsData, setPneumaticsData] = useSectionData(
+        controlDataNameMap.pneumaticsDataNameMap
+    );
+
+    const [navigationData, setNavigationData] = useSectionData(
+        controlDataNameMap.navigationDataNameMap
+    );
+
+    function setControlData(boards: PodData["boards"]) {
+        setPneumaticsData(boards);
+        setNavigationData(boards);
+    }
+
+    const controlData = {
+        pneumaticsData,
+        navigationData,
+    };
+
+    return [controlData, setControlData];
+}

--- a/src/components/ControlSections/hooks/useSectionData.ts
+++ b/src/components/ControlSections/hooks/useSectionData.ts
@@ -1,0 +1,64 @@
+import {
+    ModelNameMap,
+    SectionData,
+    isAdditionalValues,
+} from "components/ControlSections/types/SectionData";
+import { useState } from "react";
+import { PodData } from "models/PodData/PodData";
+import { Measurement } from "models/PodData/Measurement";
+import { getMeasurement } from "models/PodData/PodData";
+import { getDefaultMeasurement } from "models/PodData/Measurement";
+
+export function useSectionData<Properties extends string>(
+    nameMap: ModelNameMap<Properties>
+): [SectionData<Properties>, (boards: PodData["boards"]) => void] {
+    const [sectionData, setSectionData] = useState<SectionData<Properties>>(
+        getDefaultData()
+    );
+
+    function getDefaultData(): SectionData<Properties> {
+        const defaultData: { [key: string]: Measurement | Measurement[] } = {};
+        Object.keys(nameMap).map((guiName) => {
+            if (!isAdditionalValues(guiName)) {
+                defaultData[guiName] = getDefaultMeasurement();
+            } else {
+                defaultData["additionalValues"] = [];
+            }
+        });
+
+        return defaultData as SectionData<Properties>;
+    }
+
+    function setSectionDataFromBoards(boards: PodData["boards"]): void {
+        const sectionData = {} as { [key: string]: any };
+
+        for (const [guiName, measurementNameOrArray] of Object.entries(
+            nameMap
+        )) {
+            if (!isAdditionalValues(guiName)) {
+                sectionData[guiName] = getMeasurement(
+                    boards,
+                    measurementNameOrArray as string
+                );
+            } else {
+                sectionData["additionalValues"] = getAdditionalMeasurements(
+                    measurementNameOrArray as string[],
+                    boards
+                );
+            }
+        }
+        setSectionData(sectionData as SectionData<Properties>);
+    }
+
+    function getAdditionalMeasurements(
+        additionalProperties: string[],
+        boards: PodData["boards"]
+    ): Measurement[] {
+        console.log(additionalProperties);
+        return additionalProperties.map((additionalMeasurementName) => {
+            return getMeasurement(boards, additionalMeasurementName);
+        });
+    }
+
+    return [sectionData, setSectionDataFromBoards];
+}

--- a/src/components/ControlSections/types/ControlData.ts
+++ b/src/components/ControlSections/types/ControlData.ts
@@ -1,0 +1,16 @@
+import {
+    ModelNameMap,
+    SectionData,
+} from "components/ControlSections/types/SectionData";
+import { NavigationProperties } from "components/ControlSections/NavigationSection/NavigationData";
+import { PneumaticsProperties } from "components/ControlSections/PneumaticsSection/PneumaticsData";
+
+export type ControlDataNameMap = {
+    pneumaticsDataNameMap: ModelNameMap<PneumaticsProperties>;
+    navigationDataNameMap: ModelNameMap<NavigationProperties>;
+};
+
+export type ControlData = {
+    pneumaticsData: SectionData<PneumaticsProperties>;
+    navigationData: SectionData<NavigationProperties>;
+};

--- a/src/components/ControlSections/types/SectionData.ts
+++ b/src/components/ControlSections/types/SectionData.ts
@@ -1,0 +1,17 @@
+import { Measurement } from "models/PodData/Measurement";
+
+export type AdditionalValues = "additionalValues";
+
+export type ModelNameMap<T extends string> = {
+    [Key in T]: Key extends "additionalValues" ? string[] : string;
+};
+
+export type SectionData<T extends string> = {
+    [Key in T]: Key extends "additionalValues" ? Measurement[] : Measurement;
+};
+
+export function isAdditionalValues<T>(
+    property: string
+): property is "additionalValues" {
+    return property == "additionalValues";
+}

--- a/src/services/HTTPHandler.ts
+++ b/src/services/HTTPHandler.ts
@@ -1,0 +1,7 @@
+export async function fetchFromBackend(path: string) {
+    return fetch(
+        `http://${import.meta.env.VITE_SERVER_IP}:${
+            import.meta.env.VITE_SERVER_PORT
+        }${path}`
+    );
+}


### PR DESCRIPTION
This PR adds the hooks, types and functions needed for the `ControlSections`. Each Section in the `ControlPage` (not included in this PR) encapsulates related data (pneumatics, navigations, levitation, etc).

The data for each section has the following structure:
- A list of named properties, each holding a `Measurement`
- An optional property, `additionalValues`, that holds an array of `Measurements`.

An additional table has been added to the ADE to relate the name of the properties in the aformentioned data to the name of the `Measurements`. Put simply, this table functions as an adapter between the `Measurement` names from ADE and the names in the typescript code.

We can divide the type in two groups: 
- The generic types that describes all sections and a specific type for each section.
- The specific type contains the list of properties our sectionData object has. It may optionally contain a property named `additionalValues` as mentioned before.

The generic types help build the data object type for each section from the property list. This makes creating the types for a new section very easy. I have attached an example were you can see the data object type being created from the properties.

The generic types (specially when used in functions) require some assertions, which is never recommended. Unfortunately I have not found a way of creating types that don't need some assertions because of some limitations with Typescript. It could be fixed changing the structure of the data objects, but that would make them less convenient to use. I've settled with the current solution. If trouble arises in the future, a revision will be made to these types.

![image](https://user-images.githubusercontent.com/114338434/213929472-43cc973c-df27-4ff3-8202-e198606233eb.png)

