### PR TITLE
[PR1] DEV-4 Added bars

### DIFF
--- a/src/components/BarTag/Bar/Bar.scss
+++ b/src/components/BarTag/Bar/Bar.scss
@@ -1,0 +1,10 @@
+@use "src/styles/colors.scss";
+
+.barWrapper {
+    width: 0.4rem;
+    height: 100%;
+    border-radius: 10rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}

--- a/src/components/BarTag/Bar/Bar.tsx
+++ b/src/components/BarTag/Bar/Bar.tsx
@@ -1,0 +1,36 @@
+import "components/BarTag/Bar/Bar.scss";
+import { useRef } from "react";
+import { RangeBar } from "./RangeBar/RangeBar";
+import { BoolBar } from "./BoolBar/BoolBar";
+export type BarType = "range" | "temp" | "bool";
+
+type Props = {
+    type: BarType;
+    value: number | boolean | string;
+    min?: number;
+    max?: number;
+};
+
+export const Bar = ({ type, value, min, max }: Props) => {
+    const lookup = {
+        range: (
+            <RangeBar
+                type="range"
+                value={value as number}
+                min={min!}
+                max={max!}
+            />
+        ),
+        temp: (
+            <RangeBar
+                type="temp"
+                value={value as number}
+                min={min!}
+                max={max!}
+            />
+        ),
+        bool: <BoolBar isOn={value as boolean} />,
+    };
+
+    return lookup[type];
+};

--- a/src/components/BarTag/Bar/Bar.tsx
+++ b/src/components/BarTag/Bar/Bar.tsx
@@ -11,7 +11,7 @@ type Props = {
     max?: number;
 };
 
-export const Bar = ({ type, value, min, max }: Props) => {
+export const Bar = ({ type = "range", value, min, max }: Props) => {
     const lookup = {
         range: (
             <RangeBar

--- a/src/components/BarTag/Bar/BoolBar/BoolBar.module.scss
+++ b/src/components/BarTag/Bar/BoolBar/BoolBar.module.scss
@@ -1,0 +1,9 @@
+@use "src/styles/colors.scss";
+
+.on {
+    background-color: colors.getColor("stable");
+}
+
+.off {
+    background-color: colors.getColor("fault");
+}

--- a/src/components/BarTag/Bar/BoolBar/BoolBar.tsx
+++ b/src/components/BarTag/Bar/BoolBar/BoolBar.tsx
@@ -1,0 +1,10 @@
+import styles from "components/BarTag/Bar/BoolBar/BoolBar.module.scss";
+type Props = {
+    isOn: boolean;
+};
+
+export const BoolBar = ({ isOn }: Props) => {
+    return (
+        <div className={`barWrapper ${isOn ? styles.on : styles.off}`}></div>
+    );
+};

--- a/src/components/BarTag/Bar/RangeBar/RangeBar.module.scss
+++ b/src/components/BarTag/Bar/RangeBar/RangeBar.module.scss
@@ -1,0 +1,41 @@
+@use "src/styles/colors.scss";
+
+.tempWrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.rangeBarWrapper {
+    border: 2px solid;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
+    .content {
+        width: 100%;
+        background-color: white;
+    }
+}
+
+.range {
+    border-color: colors.getColor("stable");
+    background-color: colors.getColor("stable");
+}
+
+.temp {
+    border-color: colors.getColor("fault");
+    background-color: colors.getColor("fault");
+}
+
+.bulb {
+    flex-shrink: 0;
+    margin-top: -110%;
+    width: 200%;
+    aspect-ratio: 1/1;
+    border-radius: 50%;
+    z-index: 1;
+    background-color: colors.getColor("fault");
+}

--- a/src/components/BarTag/Bar/RangeBar/RangeBar.tsx
+++ b/src/components/BarTag/Bar/RangeBar/RangeBar.tsx
@@ -1,0 +1,37 @@
+import styles from "components/BarTag/Bar/RangeBar/RangeBar.module.scss";
+type Props = {
+    type: "range" | "temp";
+    value: number;
+    min: number;
+    max: number;
+};
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function normalize(value: number, min: number, max: number) {
+    return (value - min) / (max - min);
+}
+
+export const RangeBar = ({ type, value, min, max }: Props) => {
+    const oppositeHeight =
+        (1 - normalize(clamp(value, min, max), min, max)) * 100;
+    return (
+        <div className={type == "temp" ? styles.tempWrapper : ""}>
+            <div
+                className={`barWrapper ${styles.rangeBarWrapper} ${
+                    type == "range" ? styles.range : styles.temp
+                }`}
+            >
+                <div
+                    className={styles.content}
+                    style={{
+                        height: `${oppositeHeight}%`,
+                    }}
+                ></div>
+            </div>
+            {type == "temp" && <div className={styles.bulb}></div>}
+        </div>
+    );
+};

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,0 +1,16 @@
+$colors: (
+    stable: rgb(105, 236, 105),
+    fault: rgb(233, 99, 99),
+    text: #1a3c3a,
+    light1: hsl(191, 4%, 99%),
+);
+
+:root {
+    @each $name, $color in $colors {
+        --color-#{$name}: #{$color};
+    }
+}
+
+@function getColor($color) {
+    @return var(--color-#{$color});
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,0 +1,18 @@
+@use "fonts.scss";
+
+* {
+    box-sizing: border-box;
+    @include fonts.default-text;
+}
+
+body {
+    margin: 0;
+}
+
+.tagWrapper {
+    border: 1px solid black;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    width: fit-content;
+    height: fit-content;
+}


### PR DESCRIPTION
This PR adds the moving bar that goes in the value tags (picture below). There are three variants: range, temp and bool. The only difference between the range and the temp is the colour and the bulb at the bottom. It also adjusts the size of the bulb relative to the bar width.

![image](https://user-images.githubusercontent.com/114338434/216118595-bedd9383-31d9-4882-969b-6d113be75c8e.png)

[range-bar.webm](https://user-images.githubusercontent.com/114338434/216118607-6d68f0c4-51cc-49cc-a0e8-dcff18f7d989.webm)
