### PR TITLE
[PR1] DEV-5 Added GaugeTag

### DIFF
--- a/src/components/GaugeTag/Gauge/Arc/Arc.tsx
+++ b/src/components/GaugeTag/Gauge/Arc/Arc.tsx
@@ -22,23 +22,20 @@ export const Arc = ({
     const dashArray = `${filledArc} ${circumference}`;
     const transform = `rotate(${-90 - sweep / 2}, ${radius}, ${radius})`;
     return (
-        <g
+        <circle
             viewBox={`0 0 ${radius * 2} ${radius * 2}`}
             className={className}
-        >
-            <circle
-                cx={radius}
-                cy={radius}
-                fill="transparent"
-                r={innerRadius}
-                strokeWidth={strokeWidth}
-                strokeDasharray={dashArray}
-                strokeLinecap={"round"}
-                transform={transform}
-                style={{
-                    transition: "stroke-dasharray 0.1s linear",
-                }}
-            />
-        </g>
+            cx={radius}
+            cy={radius}
+            fill="transparent"
+            r={innerRadius}
+            strokeWidth={strokeWidth}
+            strokeDasharray={dashArray}
+            strokeLinecap={"round"}
+            transform={transform}
+            style={{
+                transition: "stroke-dasharray 0.1s linear",
+            }}
+        />
     );
 };

--- a/src/components/GaugeTag/Gauge/Arc/Arc.tsx
+++ b/src/components/GaugeTag/Gauge/Arc/Arc.tsx
@@ -1,19 +1,18 @@
 type Props = {
     sweep: number;
-    strokeWidth: number;
     percentage: number;
-    viewBoxLength: number;
-    className?: string;
+    radius: number;
+    strokeWidth: number;
+    className: string;
 };
 
 export const Arc = ({
     sweep,
     strokeWidth,
     percentage,
-    viewBoxLength,
+    radius,
     className,
 }: Props) => {
-    const radius = viewBoxLength / 2;
     const innerRadius = radius - strokeWidth / 2;
     const circumference = 2 * Math.PI * innerRadius;
     const fullArc = circumference * (sweep / 360);
@@ -24,8 +23,8 @@ export const Arc = ({
     const transform = `rotate(${-90 - sweep / 2}, ${radius}, ${radius})`;
     return (
         <g
+            viewBox={`0 0 ${radius * 2} ${radius * 2}`}
             className={className}
-            viewBox={`0 0 ${viewBoxLength} ${viewBoxLength}`}
         >
             <circle
                 cx={radius}
@@ -36,6 +35,9 @@ export const Arc = ({
                 strokeDasharray={dashArray}
                 strokeLinecap={"round"}
                 transform={transform}
+                style={{
+                    transition: "stroke-dasharray 0.1s linear",
+                }}
             />
         </g>
     );

--- a/src/components/GaugeTag/Gauge/Arc/Arc.tsx
+++ b/src/components/GaugeTag/Gauge/Arc/Arc.tsx
@@ -1,0 +1,42 @@
+type Props = {
+    sweep: number;
+    strokeWidth: number;
+    percentage: number;
+    viewBoxLength: number;
+    className?: string;
+};
+
+export const Arc = ({
+    sweep,
+    strokeWidth,
+    percentage,
+    viewBoxLength,
+    className,
+}: Props) => {
+    const radius = viewBoxLength / 2;
+    const innerRadius = radius - strokeWidth / 2;
+    const circumference = 2 * Math.PI * innerRadius;
+    const fullArc = circumference * (sweep / 360);
+    const filledArc = fullArc * (percentage / 100);
+
+    // Setting circunference as the length of the gap ensures no second dash is drawn
+    const dashArray = `${filledArc} ${circumference}`;
+    const transform = `rotate(${-90 - sweep / 2}, ${radius}, ${radius})`;
+    return (
+        <g
+            className={className}
+            viewBox={`0 0 ${viewBoxLength} ${viewBoxLength}`}
+        >
+            <circle
+                cx={radius}
+                cy={radius}
+                fill="transparent"
+                r={innerRadius}
+                strokeWidth={strokeWidth}
+                strokeDasharray={dashArray}
+                strokeLinecap={"round"}
+                transform={transform}
+            />
+        </g>
+    );
+};

--- a/src/components/GaugeTag/Gauge/BackgroundArc/BackgroundArc.module.scss
+++ b/src/components/GaugeTag/Gauge/BackgroundArc/BackgroundArc.module.scss
@@ -1,0 +1,3 @@
+.maskArc {
+    stroke: white;
+}

--- a/src/components/GaugeTag/Gauge/BackgroundArc/BackgroundArc.tsx
+++ b/src/components/GaugeTag/Gauge/BackgroundArc/BackgroundArc.tsx
@@ -1,0 +1,43 @@
+import styles from "components/GaugeTag/Gauge/BackgroundArc/BackgroundArc.module.scss";
+import { Arc } from "components/GaugeTag/Gauge/Arc/Arc";
+type Props = React.ComponentProps<typeof Arc>;
+
+export const BackgroundArc = ({
+    percentage,
+    radius,
+    strokeWidth,
+    sweep,
+    className,
+}: Props) => {
+    return (
+        <>
+            <defs>
+                <mask id="myMask">
+                    <Arc
+                        sweep={sweep}
+                        radius={radius}
+                        strokeWidth={strokeWidth}
+                        percentage={percentage}
+                        className={styles.maskArc}
+                    ></Arc>
+                </mask>
+            </defs>
+
+            <foreignObject
+                x="0"
+                y="0"
+                width="100%"
+                height="100%"
+                mask="url(#myMask)"
+            >
+                <div
+                    className={className}
+                    style={{
+                        width: "100%",
+                        height: "100%",
+                    }}
+                />
+            </foreignObject>
+        </>
+    );
+};

--- a/src/components/GaugeTag/Gauge/Gauge.module.scss
+++ b/src/components/GaugeTag/Gauge/Gauge.module.scss
@@ -1,24 +1,11 @@
-.gradientDiv {
-    width: 100%;
-    height: 100%;
-    background: conic-gradient(from 180deg, green, yellow, orange, red);
-}
-
 .backgroundArc {
     stroke: rgba(0, 0, 0, 0.049);
 }
 
 .radialShadowArc {
-    stroke: url(#myGradient);
-    > * {
-        transition: stroke-dasharray 0.1s linear;
-    }
+    background: radial-gradient(#b1b1b1d4 30%, rgb(0 0 0 / 0%) 70%);
 }
 
-.maskArc {
-    stroke: white;
-
-    > * {
-        transition: stroke-dasharray 0.1s linear;
-    }
+.rainbowArc {
+    background: conic-gradient(from 180deg, green, yellow, orange, red);
 }

--- a/src/components/GaugeTag/Gauge/Gauge.module.scss
+++ b/src/components/GaugeTag/Gauge/Gauge.module.scss
@@ -1,0 +1,24 @@
+.gradientDiv {
+    width: 100%;
+    height: 100%;
+    background: conic-gradient(from 180deg, green, yellow, orange, red);
+}
+
+.backgroundArc {
+    stroke: rgba(0, 0, 0, 0.049);
+}
+
+.radialShadowArc {
+    stroke: url(#myGradient);
+    > * {
+        transition: stroke-dasharray 0.1s linear;
+    }
+}
+
+.maskArc {
+    stroke: white;
+
+    > * {
+        transition: stroke-dasharray 0.1s linear;
+    }
+}

--- a/src/components/GaugeTag/Gauge/Gauge.tsx
+++ b/src/components/GaugeTag/Gauge/Gauge.tsx
@@ -1,5 +1,6 @@
-import { clampAndNormalize, toRadians } from "math";
+import { clampAndNormalize } from "math";
 import { Arc } from "./Arc/Arc";
+import { BackgroundArc } from "./BackgroundArc/BackgroundArc";
 import styles from "components/GaugeTag/Gauge/Gauge.module.scss";
 
 type Props = {
@@ -11,20 +12,6 @@ type Props = {
     max: number;
 };
 
-function getGaugeSize(radius: number, sweep: number): [number, number] {
-    let width: number, height: number;
-
-    if (sweep < 180) {
-        width = 2 * radius * Math.sin(toRadians(sweep / 2));
-        height = radius;
-    } else {
-        width = 2 * radius;
-        height = radius + radius * Math.sin(toRadians(sweep / 2 - 90));
-    }
-
-    return [width, height];
-}
-
 export const Gauge = ({
     className,
     sweep,
@@ -35,65 +22,37 @@ export const Gauge = ({
 }: Props) => {
     const radius = 500;
     const percentage = clampAndNormalize(value, min, max) * 100;
-    const [width, height] = getGaugeSize(radius, sweep);
     return (
         <svg
             className={className}
             width="1em"
             height="1em"
-            // viewBox={`${radius - width / 2} 0 ${width} ${height}`}
             viewBox={`0 0 ${radius * 2} ${radius * 2}`}
             xmlns="http://www.w3.org/2000/svg"
         >
             <Arc
                 className={styles.backgroundArc}
                 sweep={sweep}
+                radius={radius}
                 strokeWidth={strokeWidth}
                 percentage={100}
-                viewBoxLength={radius * 2}
             ></Arc>
-            <defs>
-                <mask id="myMask">
-                    <Arc
-                        className={styles.maskArc}
-                        sweep={sweep}
-                        strokeWidth={strokeWidth}
-                        percentage={percentage}
-                        viewBoxLength={radius * 2}
-                    ></Arc>
-                </mask>
 
-                <radialGradient
-                    id="myGradient"
-                    r="55%"
-                >
-                    <stop
-                        offset="40%"
-                        stop-color="#c9c9c9a0"
-                    />
-                    <stop
-                        offset="100%"
-                        stop-color="#c9c9c900"
-                    />
-                </radialGradient>
-            </defs>
-
-            <foreignObject
-                x="0"
-                y="0"
-                width="100%"
-                height="100%"
-                mask="url(#myMask)"
-            >
-                <div className={styles.gradientDiv} />
-            </foreignObject>
-            <Arc
-                className={styles.radialShadowArc}
+            <BackgroundArc
                 sweep={sweep}
-                strokeWidth={strokeWidth}
+                className={styles.rainbowArc}
                 percentage={percentage}
-                viewBoxLength={radius * 2}
-            ></Arc>
+                radius={radius}
+                strokeWidth={strokeWidth}
+            ></BackgroundArc>
+
+            <BackgroundArc
+                sweep={sweep}
+                className={styles.radialShadowArc}
+                percentage={percentage}
+                radius={radius}
+                strokeWidth={strokeWidth}
+            ></BackgroundArc>
         </svg>
     );
 };

--- a/src/components/GaugeTag/Gauge/Gauge.tsx
+++ b/src/components/GaugeTag/Gauge/Gauge.tsx
@@ -1,0 +1,99 @@
+import { clampAndNormalize, toRadians } from "math";
+import { Arc } from "./Arc/Arc";
+import styles from "components/GaugeTag/Gauge/Gauge.module.scss";
+
+type Props = {
+    className: string;
+    sweep: number;
+    strokeWidth: number;
+    value: number;
+    min: number;
+    max: number;
+};
+
+function getGaugeSize(radius: number, sweep: number): [number, number] {
+    let width: number, height: number;
+
+    if (sweep < 180) {
+        width = 2 * radius * Math.sin(toRadians(sweep / 2));
+        height = radius;
+    } else {
+        width = 2 * radius;
+        height = radius + radius * Math.sin(toRadians(sweep / 2 - 90));
+    }
+
+    return [width, height];
+}
+
+export const Gauge = ({
+    className,
+    sweep,
+    strokeWidth,
+    value,
+    min,
+    max,
+}: Props) => {
+    const radius = 500;
+    const percentage = clampAndNormalize(value, min, max) * 100;
+    const [width, height] = getGaugeSize(radius, sweep);
+    return (
+        <svg
+            className={className}
+            width="1em"
+            height="1em"
+            // viewBox={`${radius - width / 2} 0 ${width} ${height}`}
+            viewBox={`0 0 ${radius * 2} ${radius * 2}`}
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <Arc
+                className={styles.backgroundArc}
+                sweep={sweep}
+                strokeWidth={strokeWidth}
+                percentage={100}
+                viewBoxLength={radius * 2}
+            ></Arc>
+            <defs>
+                <mask id="myMask">
+                    <Arc
+                        className={styles.maskArc}
+                        sweep={sweep}
+                        strokeWidth={strokeWidth}
+                        percentage={percentage}
+                        viewBoxLength={radius * 2}
+                    ></Arc>
+                </mask>
+
+                <radialGradient
+                    id="myGradient"
+                    r="55%"
+                >
+                    <stop
+                        offset="40%"
+                        stop-color="#c9c9c9a0"
+                    />
+                    <stop
+                        offset="100%"
+                        stop-color="#c9c9c900"
+                    />
+                </radialGradient>
+            </defs>
+
+            <foreignObject
+                x="0"
+                y="0"
+                width="100%"
+                height="100%"
+                mask="url(#myMask)"
+            >
+                <div className={styles.gradientDiv} />
+            </foreignObject>
+            <Arc
+                className={styles.radialShadowArc}
+                sweep={sweep}
+                strokeWidth={strokeWidth}
+                percentage={percentage}
+                viewBoxLength={radius * 2}
+            ></Arc>
+        </svg>
+    );
+};

--- a/src/components/GaugeTag/GaugeTag.module.scss
+++ b/src/components/GaugeTag/GaugeTag.module.scss
@@ -1,0 +1,42 @@
+.gaugeTagWrapper {
+    display: grid;
+    grid-template-columns: min-content;
+    justify-items: center;
+    align-items: center;
+    margin-bottom: -1.87em;
+}
+
+.gauge {
+    grid-row-start: 1;
+    grid-column-start: 1;
+    font-size: 10em;
+}
+
+.measurementWrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    grid-row-start: 1;
+    grid-column-start: 1;
+    font-size: inherit;
+
+    .name {
+        font-weight: inherit;
+        font-size: 0.7em;
+        font-weight: 300;
+    }
+
+    .value {
+        font-weight: inherit;
+        font-size: 1.8em;
+        font-weight: 400;
+    }
+
+    .units {
+        font-weight: inherit;
+        font-size: 1em;
+        font-weight: 400;
+    }
+}

--- a/src/components/GaugeTag/GaugeTag.tsx
+++ b/src/components/GaugeTag/GaugeTag.tsx
@@ -1,0 +1,35 @@
+import styles from "components/GaugeTag/GaugeTag.module.scss";
+import { Gauge } from "components/GaugeTag/Gauge/Gauge";
+
+type Props = {
+    className: string;
+    strokeWidth: number;
+    value: number;
+    min: number;
+    max: number;
+};
+export const GaugeTag = ({
+    className,
+    strokeWidth,
+    value,
+    min,
+    max,
+}: Props) => {
+    return (
+        <article className={`${styles.gaugeTagWrapper} ${className}`}>
+            <Gauge
+                className={styles.gauge}
+                sweep={250}
+                strokeWidth={strokeWidth}
+                value={value}
+                min={min}
+                max={max}
+            />
+            <div className={styles.measurementWrapper}>
+                <div className={styles.name}>BatteryVoltage</div>
+                <div className={styles.value}>{value.toFixed(2)}</div>
+                <div className={styles.units}>Amp</div>
+            </div>
+        </article>
+    );
+};

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,0 +1,41 @@
+@use "colors.scss";
+
+$font-families: (
+    default: "Inter",
+);
+
+$font-sizes: (
+    default: 1.4rem,
+    small: 1rem,
+);
+
+$font-weights: (
+    bold: 600,
+    normal: 400,
+    light: 300,
+);
+
+:root {
+    @each $name, $font in $font-families {
+        --font-family-#{$name}: #{$font};
+    }
+
+    @each $name, $size in $font-sizes {
+        --font-size-#{$name}: #{$size};
+    }
+
+    @each $name, $weight in $font-weights {
+        --font-weight-#{$name}: #{$weight};
+    }
+}
+
+@mixin default-text {
+    font-family: var(--font-family-default);
+    font-size: var(--font-size-default);
+    font-weight: var(--font-weight-normal);
+    color: colors.getColor("text");
+}
+
+@function getFontSize($size) {
+    @return var(--font-size-#{$size});
+}


### PR DESCRIPTION
This PR adds the `GaugeTag` component. It's made with SVG. Its size is based on the font size. That way, the text and the svg can scale together. One crucial implementation detail is that the arc is part of a circle's stroke. It's not possible to apply an angular gradient (the rainbow gradient in the video) the stroke of an SVG shape, only linear and radial gradients. To overcome this, I've added a `div` inside the SVG (with the `foreignObject` element). Then, I add the gradient to the div with CSS and cut the shape of `div` with a `mask` that uses the `Arc` as its shape. A `mask` uses a path (in this case the `Arc`) as a shape to cut something else.

[gauge_pr.webm](https://user-images.githubusercontent.com/114338434/216654420-fcc6f3f7-8a88-4608-9be1-ed4a865b34c6.webm)
