### PR TITLE
[PR1] Added global styles

### DIFF
--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,12 +1,5 @@
 @use "sass:color";
 
-// $colors: (
-//     stable: rgb(105, 236, 105),
-//     fault: rgb(233, 99, 99),
-//     text: #1a3c3a,
-//     light1: hsl(191, 4%, 99%),
-// );
-
 $key-colors: (
     primary: hsl(192, 28%, 40%),
     tertiary: hsl(27, 78%, 40%),

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,16 +1,31 @@
-$colors: (
-    stable: rgb(105, 236, 105),
-    fault: rgb(233, 99, 99),
-    text: #1a3c3a,
-    light1: hsl(191, 4%, 99%),
+@use "sass:color";
+
+// $colors: (
+//     stable: rgb(105, 236, 105),
+//     fault: rgb(233, 99, 99),
+//     text: #1a3c3a,
+//     light1: hsl(191, 4%, 99%),
+// );
+
+$key-colors: (
+    primary: hsl(192, 28%, 40%),
+    tertiary: hsl(27, 78%, 40%),
 );
 
-:root {
-    @each $name, $color in $colors {
-        --color-#{$name}: #{$color};
+$lightnesses: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100;
+
+@mixin globalColors {
+    @each $name, $color in $key-colors {
+        @each $lightness in $lightnesses {
+            --color-#{$name}-#{$lightness}: hsl(
+                #{color.hue($color)},
+                #{color.saturation($color)},
+                #{$lightness}#{"%"}
+            );
+        }
     }
 }
 
-@function getColor($color) {
-    @return var(--color-#{$color});
+@function getColor($name, $lightness) {
+    @return var(--color-#{$name}-#{$lightness});
 }

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,4 +1,4 @@
-@use "colors.scss";
+@use "./colors.scss";
 
 $font-families: (
     default: "Inter",
@@ -15,7 +15,7 @@ $font-weights: (
     light: 300,
 );
 
-:root {
+@mixin globalFontStyles {
     @each $name, $font in $font-families {
         --font-family-#{$name}: #{$font};
     }
@@ -33,7 +33,7 @@ $font-weights: (
     font-family: var(--font-family-default);
     font-size: var(--font-size-default);
     font-weight: var(--font-weight-normal);
-    color: colors.getColor("text");
+    color: colors.getColor("primary", 20);
 }
 
 @function getFontSize($size) {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,13 @@
-@use "fonts.scss";
+@use "./colors.scss";
+@use "./fonts.scss";
+
+:root {
+    @include fonts.globalFontStyles;
+}
+
+:root {
+    @include colors.globalColors;
+}
 
 * {
     box-sizing: border-box;


### PR DESCRIPTION
This PR adds the font and colour styles used throughout the frontend. The colours have been created using a method described in [Material Design 3](https://m3.material.io/styles/color/the-color-system/key-colors-tones): from a key colour, you generate 13 tones. The roles of each tone will be defined as the GUI is developed. Take into account that you don't have to use all 13 - picking just 4 is fine.

I've defined all colours in a mixin called `globalColors` and included it in the root. You may notice the `globalColors` mixin and the `globalFontStyles` mixin are included in different selectors. This is to separate them in the dev tools (see picture).

It would be interesting to look into what the material 3 guide says about fonts.

![image](https://user-images.githubusercontent.com/114338434/216785468-d71484ba-4719-4a9f-9fbf-66d2865f15f8.png)
 