### PR TITLE
Fixed WebSocketBroker

### DIFF
--- a/src/services/WebSocketBroker/types.ts
+++ b/src/services/WebSocketBroker/types.ts
@@ -1,6 +1,6 @@
 export type Callback = (msg: any) => void;
 
 export type BackendMessage<T = any> = {
-    type: string;
+    topic: string;
     msg: T;
 };


### PR DESCRIPTION
This PR makes the `WebSocketBroker` a singleton. That means that only one instance of the class can exist. This is achieved by having a static property, `instance`, which stores the single instance of the class. As you can see in the constructor, we check if an instance already exists. If it does, we return it. If not, we continue with the constructor.

Returning a value from the constructor might seem confusing at first, but it's simple to understand. Here you have an [article that goes into detail](https://javascript.info/constructor-new). Basically, when you return an object from a constructor you get the returned object instead of a new instance.

Enforcing the singleton pattern via the constructor is not recommended as it limits the possibilities of the class i.e. you might want to create multiple instaces in the future. For now, this is the most optimal solution, other alternatives will be looked into in the future.